### PR TITLE
[SYCL] Add tests for command_graph extension record and replay

### DIFF
--- a/SYCL/CommandGraph/graph_common.hpp
+++ b/SYCL/CommandGraph/graph_common.hpp
@@ -1,0 +1,131 @@
+// Common header for SYCL command_graph tests
+
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/oneapi/experimental/graph.hpp>
+
+#include <numeric>
+
+// Some test constants
+constexpr size_t size = 1024;
+constexpr unsigned iterations = 5;
+
+// Kernel declarations for use in run_kernels()
+class increment_kernel;
+class add_kernel;
+class subtract_kernel;
+class decrement_kernel;
+
+// Kernel declarations for use in run_kernels_usm()
+class increment_kernel_usm;
+class add_kernel_usm;
+class subtract_kernel_usm;
+class decrement_kernel_usm;
+
+using namespace sycl;
+
+/** Runs a series of kernels based on the examples from the initial Graphs
+ * sample code repo.
+ *
+ */
+template <typename T>
+void run_kernels(sycl::queue q, const size_t size, buffer<T> dataA,
+                 buffer<T> dataB, buffer<T> dataC) {
+  // Read & write Buffer A
+  q.submit([&](handler &cgh) {
+    auto pData = dataA.template get_access<access::mode::read_write>(cgh);
+    cgh.parallel_for<increment_kernel>(range<1>(size),
+                                       [=](item<1> id) { pData[id]++; });
+  });
+
+  // Reads Buffer A
+  // Read & Write Buffer B
+  q.submit([&](handler &cgh) {
+    auto pData1 = dataA.template get_access<access::mode::read>(cgh);
+    auto pData2 = dataB.template get_access<access::mode::read_write>(cgh);
+    cgh.parallel_for<add_kernel>(range<1>(size),
+                                 [=](item<1> id) { pData2[id] += pData1[id]; });
+  });
+
+  // Reads Buffer A
+  // Read & writes Buffer C
+  q.submit([&](handler &cgh) {
+    auto pData1 = dataA.template get_access<access::mode::read>(cgh);
+    auto pData2 = dataC.template get_access<access::mode::read_write>(cgh);
+    cgh.parallel_for<subtract_kernel>(
+        range<1>(size), [=](item<1> id) { pData2[id] -= pData1[id]; });
+  });
+
+  // Read & write Buffers B and C
+  q.submit([&](handler &cgh) {
+    auto pData1 = dataB.template get_access<access::mode::read_write>(cgh);
+    auto pData2 = dataC.template get_access<access::mode::read_write>(cgh);
+    cgh.parallel_for<decrement_kernel>(range<1>(size), [=](item<1> id) {
+      pData1[id]--;
+      pData2[id]--;
+    });
+  });
+}
+
+/** Runs a series of kernels based on the examples from the initial Graphs
+ * sample code repo.
+ *
+ */
+template <typename T>
+void run_kernels_usm(sycl::queue q, const size_t size, T *dataA, T *dataB,
+                     T *dataC) {
+  // Read & write Buffer A
+  q.submit([&](handler &cgh) {
+    cgh.parallel_for<increment_kernel_usm>(range<1>(size), [=](item<1> id) {
+      auto linID = id.get_linear_id();
+      dataA[linID]++;
+    });
+  });
+
+  // Reads Buffer A
+  // Read & Write Buffer B
+  q.submit([&](handler &cgh) {
+    cgh.parallel_for<add_kernel_usm>(range<1>(size), [=](item<1> id) {
+      auto linID = id.get_linear_id();
+      dataB[linID] += dataA[linID];
+    });
+  });
+
+  // Reads Buffer A
+  // Read & writes Buffer C
+  q.submit([&](handler &cgh) {
+    cgh.parallel_for<subtract_kernel_usm>(range<1>(size), [=](item<1> id) {
+      auto linID = id.get_linear_id();
+      dataC[linID] -= dataA[linID];
+    });
+  });
+
+  // Read & write Buffers B and C
+  q.submit([&](handler &cgh) {
+    cgh.parallel_for<decrement_kernel_usm>(range<1>(size), [=](item<1> id) {
+      auto linID = id.get_linear_id();
+      dataB[linID]--;
+      dataC[linID]--;
+    });
+  });
+}
+
+/** Calculates reference data on the host for a given number of executions of
+ * the kernels in run_kernels()
+ *
+ */
+template <typename T>
+void calculate_reference_data(size_t iterations, size_t size,
+                              std::vector<T> &referenceA,
+                              std::vector<T> &referenceB,
+                              std::vector<T> &referenceC) {
+  for (unsigned n = 0; n < iterations; n++) {
+    for (size_t i = 0; i < size; i++) {
+      referenceA[i]++;
+      referenceB[i] += referenceA[i];
+      referenceC[i] -= referenceA[i];
+      referenceB[i]--;
+      referenceC[i]--;
+    }
+  }
+}

--- a/SYCL/CommandGraph/graph_finalize_empty.cpp
+++ b/SYCL/CommandGraph/graph_finalize_empty.cpp
@@ -13,7 +13,7 @@ using namespace sycl;
 int main() {
   queue testQueue;
 
-  ext::codeplay::command_graph<
+  ext::oneapi::experimental::command_graph<
       ext::oneapi::experimental::graph_state::modifiable>
       graph;
   auto graphExec = graph.finalize(testQueue.get_context());

--- a/SYCL/CommandGraph/graph_finalize_empty.cpp
+++ b/SYCL/CommandGraph/graph_finalize_empty.cpp
@@ -1,0 +1,25 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/**  Tests the ability to finalize a command graph without recording any nodes
+ * to it.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  ext::codeplay::command_graph<
+      ext::oneapi::experimental::graph_state::modifiable>
+      graph;
+  auto graphExec = graph.finalize(testQueue.get_context());
+
+  testQueue.submit(graphExec);
+  testQueue.wait();
+
+  return 0;
+}

--- a/SYCL/CommandGraph/graph_finalize_twice.cpp
+++ b/SYCL/CommandGraph/graph_finalize_twice.cpp
@@ -1,0 +1,22 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/**  Tests calling finalize() more than once on the same command_graph.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  ext::codeplay::command_graph<
+      ext::oneapi::experimental::graph_state::modifiable>
+      graph;
+  auto graphExec = graph.finalize(testQueue.get_context());
+  auto graphExec2 = graph.finalize(testQueue.get_context());
+
+  return 0;
+}

--- a/SYCL/CommandGraph/graph_finalize_twice.cpp
+++ b/SYCL/CommandGraph/graph_finalize_twice.cpp
@@ -12,7 +12,7 @@ using namespace sycl;
 int main() {
   queue testQueue;
 
-  ext::codeplay::command_graph<
+  ext::oneapi::experimental::command_graph<
       ext::oneapi::experimental::graph_state::modifiable>
       graph;
   auto graphExec = graph.finalize(testQueue.get_context());

--- a/SYCL/CommandGraph/graph_queue_info.cpp
+++ b/SYCL/CommandGraph/graph_queue_info.cpp
@@ -1,0 +1,30 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/**  Tests the return values from queue graph functions which change the
+ * internal queue state
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  bool failure = false;
+  ext::codeplay::queue_state state = testQueue.get_info<info::queue::state>();
+  failure |= (state == ext::oneapi::experimental::queue_state::executing);
+
+  ext::codeplay::command_graph<ext::codeplay::graph_state::recordable> graph;
+  testQueue.begin_recording(graph);
+  state = testQueue.get_info<info::queue::state>();
+  failure |= (state == ext::oneapi::experimental::queue_state::recording);
+
+  testQueue.end_recording();
+  state = testQueue.get_info<info::queue::state>();
+  failure |= (state == ext::oneapi::experimental::queue_state::executing);
+
+  return failure;
+}

--- a/SYCL/CommandGraph/graph_queue_info.cpp
+++ b/SYCL/CommandGraph/graph_queue_info.cpp
@@ -14,10 +14,13 @@ int main() {
   queue testQueue;
 
   bool failure = false;
-  ext::codeplay::queue_state state = testQueue.get_info<info::queue::state>();
+  ext::oneapi::experimental::queue_state state =
+      testQueue.get_info<info::queue::state>();
   failure |= (state == ext::oneapi::experimental::queue_state::executing);
 
-  ext::codeplay::command_graph<ext::codeplay::graph_state::recordable> graph;
+  ext::oneapi::experimental::command_graph<
+      ext::oneapi::experimental::graph_state::modifiable>
+      graph;
   testQueue.begin_recording(graph);
   state = testQueue.get_info<info::queue::state>();
   failure |= (state == ext::oneapi::experimental::queue_state::recording);

--- a/SYCL/CommandGraph/graph_record_after_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_after_finalize.cpp
@@ -1,0 +1,92 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** This test creates a graph, finalizes it, then continues to add new nodes to
+ * the graph before finalizing and executing the second graph.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+class vector_plus_equals;
+class write_to_output;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  std::vector<T> dataA(size), dataB(size), dataC(size), dataOut(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+  std::iota(dataOut.begin(), dataOut.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceC(dataC);
+  std::vector<T> referenceOut(dataOut);
+  for (unsigned n = 0; n < iterations * 2; n++) {
+    for (size_t i = 0; i < size; i++) {
+      referenceC[i] += (dataA[i] + dataB[i]);
+      if (n >= iterations)
+        referenceOut[i] += referenceC[i] + 1;
+    }
+  }
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+    buffer<T> bufferOut{dataOut.data(), range<1>{dataOut.size()}};
+
+    testQueue.begin_recording(graph);
+
+    // Vector add to some buffer
+    testQueue.submit([&](handler &cgh) {
+      auto ptrA = bufferA.template get_access<access::mode::read>(cgh);
+      auto ptrB = bufferB.template get_access<access::mode::read>(cgh);
+      auto ptrC = bufferC.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<vector_plus_equals>(
+          range<1>(size), [=](item<1> id) { ptrC[id] += ptrA[id] + ptrB[id]; });
+    });
+
+    auto graphExec = graph.finalize(testQueue.get_context());
+
+    // Read and modify previous output and write to output buffer
+    testQueue.submit([&](handler &cgh) {
+      auto ptrC = bufferC.template get_access<access::mode::read>(cgh);
+      auto ptrOut =
+          bufferOut.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<write_to_output>(
+          range<1>(size), [=](item<1> id) { ptrOut[id] += ptrC[id] + 1; });
+    });
+    testQueue.end_recording();
+
+    // Finalize a graph with the additional kernel for writing out to
+    auto graphExecAdditional = graph.finalize(testQueue.get_context());
+
+    // Execute several iterations of the graph
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+    // Execute the extended graph.
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExecAdditional);
+    }
+    // Perform a wait on all graph submissions.
+    testQueue.wait_and_throw();
+  }
+
+  bool failed = false;
+  failed = referenceC != dataC;
+  failed = referenceOut != dataOut;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_after_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_after_finalize.cpp
@@ -50,9 +50,9 @@ int main() {
 
     // Vector add to some buffer
     testQueue.submit([&](handler &cgh) {
-      auto ptrA = bufferA.template get_access<access::mode::read>(cgh);
-      auto ptrB = bufferB.template get_access<access::mode::read>(cgh);
-      auto ptrC = bufferC.template get_access<access::mode::read_write>(cgh);
+      auto ptrA = bufferA.get_access<access::mode::read>(cgh);
+      auto ptrB = bufferB.get_access<access::mode::read>(cgh);
+      auto ptrC = bufferC.get_access<access::mode::read_write>(cgh);
       cgh.parallel_for<vector_plus_equals>(
           range<1>(size), [=](item<1> id) { ptrC[id] += ptrA[id] + ptrB[id]; });
     });
@@ -61,9 +61,8 @@ int main() {
 
     // Read and modify previous output and write to output buffer
     testQueue.submit([&](handler &cgh) {
-      auto ptrC = bufferC.template get_access<access::mode::read>(cgh);
-      auto ptrOut =
-          bufferOut.template get_access<access::mode::read_write>(cgh);
+      auto ptrC = bufferC.get_access<access::mode::read>(cgh);
+      auto ptrOut = bufferOut.get_access<access::mode::read_write>(cgh);
       cgh.parallel_for<write_to_output>(
           range<1>(size), [=](item<1> id) { ptrOut[id] += ptrC[id] + 1; });
     });
@@ -85,8 +84,8 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceC != dataC;
-  failed = referenceOut != dataOut;
+  failed |= referenceC != dataC;
+  failed |= referenceOut != dataOut;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_after_use.cpp
+++ b/SYCL/CommandGraph/graph_record_after_use.cpp
@@ -57,9 +57,9 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_after_use.cpp
+++ b/SYCL/CommandGraph/graph_record_after_use.cpp
@@ -1,0 +1,65 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** This test attempts recording a set of kernels after they have already been
+ * executed once before.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  calculate_reference_data(iterations, size, referenceA, referenceB,
+                           referenceC);
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    // Run the kernels once first outside of the graph.
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+    testQueue.wait_and_throw();
+
+    testQueue.begin_recording(graph);
+
+    // Record commands to graph
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+
+    testQueue.end_recording();
+    auto graphExec = graph.finalize(testQueue.get_context());
+
+    // Execute several iterations of the graph (first iteration has already run
+    // before graph recording)
+    for (unsigned n = 1; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_basic.cpp
+++ b/SYCL/CommandGraph/graph_record_basic.cpp
@@ -1,0 +1,61 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** Tests basic recording and submission of a graph using buffers and accessors
+ * for inputs and outputs.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  calculate_reference_data(iterations, size, referenceA, referenceB,
+                           referenceC);
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    testQueue.begin_recording(graph);
+
+    // Record commands to graph
+
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+
+    testQueue.end_recording();
+    auto graphExec = graph.finalize(testQueue.get_context());
+
+    // Execute several iterations of the graph
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_basic.cpp
+++ b/SYCL/CommandGraph/graph_record_basic.cpp
@@ -53,9 +53,9 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_basic_usm.cpp
+++ b/SYCL/CommandGraph/graph_record_basic_usm.cpp
@@ -64,9 +64,9 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_basic_usm.cpp
+++ b/SYCL/CommandGraph/graph_record_basic_usm.cpp
@@ -1,0 +1,72 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** Tests basic recording and submission of a graph using USM pointers for
+ * inputs and outputs.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  calculate_reference_data(iterations, size, referenceA, referenceB,
+                           referenceC);
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    auto ptrA = malloc_device<T>(dataA.size(), testQueue);
+    testQueue.memcpy(ptrA, dataA.data(), dataA.size() * sizeof(T)).wait();
+    auto ptrB = malloc_device<T>(dataB.size(), testQueue);
+    testQueue.memcpy(ptrB, dataB.data(), dataB.size() * sizeof(T)).wait();
+    auto ptrC = malloc_device<T>(dataC.size(), testQueue);
+    testQueue.memcpy(ptrC, dataC.data(), dataC.size() * sizeof(T)).wait();
+
+    testQueue.begin_recording(graph);
+
+    // Record commands to graph
+
+    run_kernels_usm(testQueue, size, ptrA, ptrB, ptrC);
+
+    testQueue.end_recording();
+    auto graphExec = graph.finalize(testQueue.get_context());
+
+    // Execute several iterations of the graph
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+
+    testQueue.memcpy(dataA.data(), ptrA, dataA.size() * sizeof(T)).wait();
+    testQueue.memcpy(dataB.data(), ptrB, dataB.size() * sizeof(T)).wait();
+    testQueue.memcpy(dataC.data(), ptrC, dataC.size() * sizeof(T)).wait();
+
+    free(ptrA, testQueue.get_context());
+    free(ptrB, testQueue.get_context());
+    free(ptrC, testQueue.get_context());
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_concurrent_graph.cpp
+++ b/SYCL/CommandGraph/graph_record_concurrent_graph.cpp
@@ -21,7 +21,7 @@ int main() {
   queue testQueue2;
   try {
     testQueue2.begin_recording(graph);
-  } catch (cl::sycl::exception &e) {
+  } catch (sycl::exception &e) {
     auto stdErrc = e.code().value();
     if (stdErrc == static_cast<int>(errc::invalid)) {
       success = true;

--- a/SYCL/CommandGraph/graph_record_concurrent_graph.cpp
+++ b/SYCL/CommandGraph/graph_record_concurrent_graph.cpp
@@ -1,0 +1,33 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** Tests attempting to record to a command_graph when it is already being
+ * recorded to by another queue.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  bool success = false;
+
+  ext::oneapi::experimental::command_graph graph;
+  testQueue.begin_recording(graph);
+
+  queue testQueue2;
+  try {
+    testQueue2.begin_recording(graph);
+  } catch (cl::sycl::exception &e) {
+    auto stdErrc = e.code().value();
+    if (stdErrc == static_cast<int>(errc::invalid)) {
+      success = true;
+    }
+  }
+
+  testQueue.end_recording();
+  return success;
+}

--- a/SYCL/CommandGraph/graph_record_concurrent_queue.cpp
+++ b/SYCL/CommandGraph/graph_record_concurrent_queue.cpp
@@ -1,0 +1,34 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/**  Tests attempting to begin recording to a new graph when recording is
+ * already in progress on another.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  bool success = false;
+
+  ext::oneapi::experimental::command_graph graphA;
+  testQueue.begin_recording(graphA);
+
+  try {
+    ext::oneapi::experimental::command_graph graphB;
+    testQueue.begin_recording(graphB);
+  } catch (sycl::exception &e) {
+    auto stdErrc = e.code().value();
+    if (stdErrc == static_cast<int>(errc::invalid)) {
+      success = true;
+    }
+  }
+
+  testQueue.end_recording();
+
+  return success;
+}

--- a/SYCL/CommandGraph/graph_record_double_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_double_buffer.cpp
@@ -72,13 +72,13 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
 
-  failed = referenceA2 != dataA2;
-  failed = referenceB2 != dataB2;
-  failed = referenceC2 != dataC2;
+  failed |= referenceA2 != dataA2;
+  failed |= referenceB2 != dataB2;
+  failed |= referenceC2 != dataC2;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_double_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_double_buffer.cpp
@@ -1,0 +1,84 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// XFAIL: *
+
+/** Tests whole graph update by creating a double buffering scenario, where a
+ * single graph is repeatedly executed then updated to swap between two sets of
+ * buffers.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+  std::vector<T> dataA2(size), dataB2(size), dataC2(size);
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  std::iota(dataA2.begin(), dataA2.end(), 3);
+  std::iota(dataB2.begin(), dataB2.end(), 13);
+  std::iota(dataC2.begin(), dataC2.end(), 1333);
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  std::vector<T> referenceA2(dataA2), referenceB2(dataB2), referenceC2(dataC2);
+  // Calculate reference data
+  calculate_reference_data(iterations, size, referenceA, referenceB,
+                           referenceC);
+  calculate_reference_data(iterations, size, referenceA2, referenceB2,
+                           referenceC2);
+
+  {
+    ext::oneapi::experimental::command_graph graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    buffer<T> bufferA2{dataA2.data(), range<1>{dataA2.size()}};
+    buffer<T> bufferB2{dataB2.data(), range<1>{dataB2.size()}};
+    buffer<T> bufferC2{dataC2.data(), range<1>{dataC2.size()}};
+
+    testQueue.begin_recording(graph);
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+    testQueue.end_recording();
+
+    auto execGraph = graph.finalize(testQueue.get_context());
+
+    // Create second graph using other buffer set
+    ext::oneapi::experimental::command_graph graphUpdate;
+    testQueue.begin_recording(graphUpdate);
+    run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
+    testQueue.end_recording();
+
+    for (size_t i = 0; i < iterations; i++) {
+      testQueue.submit(execGraph);
+      // Update to second set of buffers
+      execGraph.update(graphUpdate);
+      testQueue.submit(execGraph);
+      // Reset back to original buffers
+      execGraph.update(graph);
+    }
+
+    testQueue.wait_and_throw();
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+
+  failed = referenceA2 != dataA2;
+  failed = referenceB2 != dataB2;
+  failed = referenceC2 != dataC2;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_finalize_while_recording.cpp
+++ b/SYCL/CommandGraph/graph_record_finalize_while_recording.cpp
@@ -25,5 +25,5 @@ int main() {
   }
 
   testQueue.end_recording();
-  return success;
+  return 0;
 }

--- a/SYCL/CommandGraph/graph_record_finalize_while_recording.cpp
+++ b/SYCL/CommandGraph/graph_record_finalize_while_recording.cpp
@@ -1,0 +1,29 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/**  Tests the ability to finalize a command graph while it is currently being
+ * recorded to.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  ext::oneapi::experimental::command_graph graph;
+  testQueue.begin_recording(graph);
+
+  try {
+    graph.finalize(testQueue.get_context());
+  } catch (sycl::exception &e) {
+    std::cout << "Exception thrown on finalize."
+              << "\n";
+    std::abort();
+  }
+
+  testQueue.end_recording();
+  return success;
+}

--- a/SYCL/CommandGraph/graph_record_host_task.cpp
+++ b/SYCL/CommandGraph/graph_record_host_task.cpp
@@ -45,9 +45,9 @@ int main() {
 
     // Vector add to output
     testQueue.submit([&](handler &cgh) {
-      auto ptrA = bufferA.template get_access<access::mode::read>(cgh);
-      auto ptrB = bufferB.template get_access<access::mode::read>(cgh);
-      auto ptrOut = bufferC.template get_access<access::mode::read_write>(cgh);
+      auto ptrA = bufferA.get_access<access::mode::read>(cgh);
+      auto ptrB = bufferB.get_access<access::mode::read>(cgh);
+      auto ptrOut = bufferC.get_access<access::mode::read_write>(cgh);
       cgh.parallel_for<host_task_add>(range<1>(size), [=](item<1> id) {
         ptrOut[id] += ptrA[id] + ptrB[id];
       });
@@ -57,8 +57,7 @@ int main() {
     testQueue.submit([&](handler &cgh) {
       // This should be access::target::host_task but it has not been
       // implemented yet.
-      auto hostC =
-          bufferC.template get_access<access::mode::read_write,
+      auto hostC = bufferC.get_access<access::mode::read_write,
                                       access::target::host_buffer>(cgh);
       cgh.host_task([=]() {
         for (size_t i = 0; i < size; i++) {
@@ -69,7 +68,7 @@ int main() {
 
     // Modify temp buffer and write to output buffer
     testQueue.submit([&](handler &cgh) {
-      auto ptrOut = bufferC.template get_access<access::mode::read_write>(cgh);
+      auto ptrOut = bufferC.get_access<access::mode::read_write>(cgh);
       cgh.parallel_for<host_task_inc>(range<1>(size),
                                       [=](item<1> id) { ptrOut[id] += 1; });
     });
@@ -86,7 +85,7 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceC != dataC;
+  failed |= referenceC != dataC;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_host_task.cpp
+++ b/SYCL/CommandGraph/graph_record_host_task.cpp
@@ -1,0 +1,92 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** This test uses a host_task within a command_graph recording
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+class host_task_add;
+class host_task_inc;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  const T modValue = T{7};
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceC(dataC);
+  for (unsigned n = 0; n < iterations; n++) {
+    for (size_t i = 0; i < size; i++) {
+      referenceC[i] += (dataA[i] + dataB[i]) + modValue + 1;
+    }
+  }
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    testQueue.begin_recording(graph);
+
+    // Vector add to output
+    testQueue.submit([&](handler &cgh) {
+      auto ptrA = bufferA.template get_access<access::mode::read>(cgh);
+      auto ptrB = bufferB.template get_access<access::mode::read>(cgh);
+      auto ptrOut = bufferC.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<host_task_add>(range<1>(size), [=](item<1> id) {
+        ptrOut[id] += ptrA[id] + ptrB[id];
+      });
+    });
+
+    // Modify the output values in a host_task
+    testQueue.submit([&](handler &cgh) {
+      // This should be access::target::host_task but it has not been
+      // implemented yet.
+      auto hostC =
+          bufferC.template get_access<access::mode::read_write,
+                                      access::target::host_buffer>(cgh);
+      cgh.host_task([=]() {
+        for (size_t i = 0; i < size; i++) {
+          hostC[i] += modValue;
+        }
+      });
+    });
+
+    // Modify temp buffer and write to output buffer
+    testQueue.submit([&](handler &cgh) {
+      auto ptrOut = bufferC.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<host_task_inc>(range<1>(size),
+                                      [=](item<1> id) { ptrOut[id] += 1; });
+    });
+    testQueue.end_recording();
+
+    auto graphExec = graph.finalize(testQueue.get_context());
+
+    // Execute several iterations of the graph
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  bool failed = false;
+  failed = referenceC != dataC;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
+++ b/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
@@ -57,9 +57,9 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
+++ b/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
@@ -1,0 +1,65 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** This test attempts creating multiple executable graphs from one modifiable
+ * graph.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  calculate_reference_data(iterations, size, referenceA, referenceB,
+                           referenceC);
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    // Run the kernels once first outside of the graph.
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+    testQueue.wait_and_throw();
+
+    testQueue.begin_recording(graph);
+
+    // Record commands to graph
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+
+    testQueue.end_recording();
+
+    // Execute several iterations of the graph (first iteration has already run
+    // before graph recording)
+    for (unsigned n = 1; n < iterations; n++) {
+      auto graphExec = graph.finalize(testQueue.get_context());
+      testQueue.submit(graphExec);
+    }
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_return_values.cpp
+++ b/SYCL/CommandGraph/graph_record_return_values.cpp
@@ -1,0 +1,36 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/**  Tests the return values from queue graph functions which change the
+ * internal queue state
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  bool failure = false;
+
+  bool changedState = testQueue.end_recording();
+  failure |= changedState;
+
+  ext::oneapi::experimental::command_graph graph;
+  changedState = testQueue.begin_recording(graph);
+  failure |= !changedState;
+
+  // Recording to same graph is not an exception
+  changedState = testQueue.begin_recording(graph);
+  failure |= changedState;
+
+  changedState = testQueue.end_recording();
+  failure |= !changedState;
+
+  changedState = testQueue.end_recording();
+  failure |= changedState;
+
+  return failure;
+}

--- a/SYCL/CommandGraph/graph_record_stream.cpp
+++ b/SYCL/CommandGraph/graph_record_stream.cpp
@@ -31,7 +31,7 @@ int main() {
 
     // Vector add to temporary output buffer
     testQueue.submit([&](handler &cgh) {
-      auto accIn = bufferIn.template get_access<access::mode::read>(cgh);
+      auto accIn = bufferIn.get_access<access::mode::read>(cgh);
       sycl::stream out(16 * 16, 16, cgh);
       cgh.parallel_for<stream_kernel>(range<1>(size), [=](item<1> id) {
         out << "Val: " << accIn[id.get_linear_id()] << sycl::endl;

--- a/SYCL/CommandGraph/graph_record_stream.cpp
+++ b/SYCL/CommandGraph/graph_record_stream.cpp
@@ -1,0 +1,51 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** This test checks that we can use a stream within a command_graph recording
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+class stream_kernel;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+  std::vector<T> dataIn(size);
+
+  // Initialize the data
+  std::iota(dataIn.begin(), dataIn.end(), 1);
+
+  {
+
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferIn{dataIn.data(), range<1>{dataIn.size()}};
+
+    testQueue.begin_recording(graph);
+
+    // Vector add to temporary output buffer
+    testQueue.submit([&](handler &cgh) {
+      auto accIn = bufferIn.template get_access<access::mode::read>(cgh);
+      sycl::stream out(16 * 16, 16, cgh);
+      cgh.parallel_for<stream_kernel>(range<1>(size), [=](item<1> id) {
+        out << "Val: " << accIn[id.get_linear_id()] << sycl::endl;
+      });
+    });
+    testQueue.end_recording();
+
+    auto graphExec = graph.finalize(testQueue.get_context());
+
+    testQueue.submit(graphExec);
+
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  return 0;
+}

--- a/SYCL/CommandGraph/graph_record_stream.cpp
+++ b/SYCL/CommandGraph/graph_record_stream.cpp
@@ -5,6 +5,9 @@
 /** This test checks that we can use a stream within a command_graph recording
  */
 
+// TODO: Output should be validated using lit mechanisms but this can be done
+// at a later point.
+
 #include "graph_common.hpp"
 
 using namespace sycl;

--- a/SYCL/CommandGraph/graph_record_sub_graph.cpp
+++ b/SYCL/CommandGraph/graph_record_sub_graph.cpp
@@ -1,0 +1,126 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** This test creates a graph, finalizes it, then submits that as a subgraph of
+ * another graph and executes that second graph.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+class sub_vec_add_kernel;
+class sub_subtract_kernel;
+class mod_input_kernel;
+class copy_out_kernel;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  // Values used to modify data inside kernels.
+  const int mod_value = 7;
+  std::vector<T> dataA(size), dataB(size), dataC(size), dataOut(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+  std::iota(dataOut.begin(), dataOut.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA);
+  std::vector<T> referenceB(dataB);
+  std::vector<T> referenceC(dataC);
+  std::vector<T> referenceOut(dataOut);
+  for (unsigned n = 0; n < iterations; n++) {
+    for (size_t i = 0; i < size; i++) {
+      referenceA[i] += mod_value;
+      referenceB[i] += mod_value;
+      referenceC[i] = (referenceA[i] + referenceB[i]);
+      referenceC[i] -= mod_value;
+      referenceOut[i] = referenceC[i] + mod_value;
+    }
+  }
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        subGraph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+    buffer<T> bufferOut{dataOut.data(), range<1>{dataOut.size()}};
+
+    // Record some operations to a graph which will later be submitted as part
+    // of another graph.
+    testQueue.begin_recording(subGraph);
+
+    // Vector add two values
+    testQueue.submit([&](handler &cgh) {
+      auto ptrA = bufferA.template get_access<access::mode::read>(cgh);
+      auto ptrB = bufferB.template get_access<access::mode::read>(cgh);
+      auto ptrC = bufferC.template get_access<access::mode::write>(cgh);
+      cgh.parallel_for<sub_vec_add_kernel>(
+          range<1>(size), [=](item<1> id) { ptrC[id] = ptrA[id] + ptrB[id]; });
+    });
+
+    // Modify the output value with some other value
+    testQueue.submit([&](handler &cgh) {
+      auto ptrC = bufferC.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<sub_subtract_kernel>(
+          range<1>(size), [=](item<1> id) { ptrC[id] -= mod_value; });
+    });
+
+    testQueue.end_recording();
+
+    auto subGraphExec = subGraph.finalize(testQueue.get_context());
+
+    ext::oneapi::experimental::command_graph mainGraph;
+
+    testQueue.begin_recording(mainGraph);
+
+    // Modify the input values.
+    testQueue.submit([&](handler &cgh) {
+      auto ptrA = bufferA.template get_access<access::mode::read_write>(cgh);
+      auto ptrB = bufferB.template get_access<access::mode::read_write>(cgh);
+      cgh.parallel_for<mod_input_kernel>(range<1>(size), [=](item<1> id) {
+        ptrA[id] += mod_value;
+        ptrB[id] += mod_value;
+      });
+    });
+
+    testQueue.submit(subGraphExec);
+
+    // Copy to another output buffer.
+    testQueue.submit([&](handler &cgh) {
+      auto ptrC = bufferC.template get_access<access::mode::read>(cgh);
+      auto ptrOut = bufferOut.template get_access<access::mode::write>(cgh);
+      cgh.parallel_for<copy_out_kernel>(range<1>(size), [=](item<1> id) {
+        ptrOut[id] = ptrC[id] + mod_value;
+      });
+    });
+
+    testQueue.end_recording();
+
+    // Finalize a graph with the additional kernel for writing out to
+    auto mainGraphExec = mainGraph.finalize(testQueue.get_context());
+
+    // Execute several iterations of the graph
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(mainGraphExec);
+    }
+    // Perform a wait on all graph submissions.
+    testQueue.wait_and_throw();
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+  failed = referenceOut != dataOut;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_sub_graph.cpp
+++ b/SYCL/CommandGraph/graph_record_sub_graph.cpp
@@ -60,16 +60,16 @@ int main() {
 
     // Vector add two values
     testQueue.submit([&](handler &cgh) {
-      auto ptrA = bufferA.template get_access<access::mode::read>(cgh);
-      auto ptrB = bufferB.template get_access<access::mode::read>(cgh);
-      auto ptrC = bufferC.template get_access<access::mode::write>(cgh);
+      auto ptrA = bufferA.get_access<access::mode::read>(cgh);
+      auto ptrB = bufferB.get_access<access::mode::read>(cgh);
+      auto ptrC = bufferC.get_access<access::mode::write>(cgh);
       cgh.parallel_for<sub_vec_add_kernel>(
           range<1>(size), [=](item<1> id) { ptrC[id] = ptrA[id] + ptrB[id]; });
     });
 
     // Modify the output value with some other value
     testQueue.submit([&](handler &cgh) {
-      auto ptrC = bufferC.template get_access<access::mode::read_write>(cgh);
+      auto ptrC = bufferC.get_access<access::mode::read_write>(cgh);
       cgh.parallel_for<sub_subtract_kernel>(
           range<1>(size), [=](item<1> id) { ptrC[id] -= mod_value; });
     });
@@ -84,8 +84,8 @@ int main() {
 
     // Modify the input values.
     testQueue.submit([&](handler &cgh) {
-      auto ptrA = bufferA.template get_access<access::mode::read_write>(cgh);
-      auto ptrB = bufferB.template get_access<access::mode::read_write>(cgh);
+      auto ptrA = bufferA.get_access<access::mode::read_write>(cgh);
+      auto ptrB = bufferB.get_access<access::mode::read_write>(cgh);
       cgh.parallel_for<mod_input_kernel>(range<1>(size), [=](item<1> id) {
         ptrA[id] += mod_value;
         ptrB[id] += mod_value;
@@ -96,8 +96,8 @@ int main() {
 
     // Copy to another output buffer.
     testQueue.submit([&](handler &cgh) {
-      auto ptrC = bufferC.template get_access<access::mode::read>(cgh);
-      auto ptrOut = bufferOut.template get_access<access::mode::write>(cgh);
+      auto ptrC = bufferC.get_access<access::mode::read>(cgh);
+      auto ptrOut = bufferOut.get_access<access::mode::write>(cgh);
       cgh.parallel_for<copy_out_kernel>(range<1>(size), [=](item<1> id) {
         ptrOut[id] = ptrC[id] + mod_value;
       });
@@ -117,10 +117,10 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
-  failed = referenceOut != dataOut;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
+  failed |= referenceOut != dataOut;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_temp_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer.cpp
@@ -49,9 +49,9 @@ int main() {
 
       // Vector add to temporary output buffer
       testQueue.submit([&](handler &cgh) {
-        auto ptrA = bufferA.template get_access<access::mode::read>(cgh);
-        auto ptrB = bufferB.template get_access<access::mode::read>(cgh);
-        auto ptrOut = bufferTemp.template get_access<access::mode::write>(cgh);
+        auto ptrA = bufferA.get_access<access::mode::read>(cgh);
+        auto ptrB = bufferB.get_access<access::mode::read>(cgh);
+        auto ptrOut = bufferTemp.get_access<access::mode::write>(cgh);
         cgh.parallel_for<vector_add_temp>(range<1>(size), [=](item<1> id) {
           ptrOut[id] = ptrA[id] + ptrB[id];
         });
@@ -59,8 +59,8 @@ int main() {
 
       // Modify temp buffer and write to output buffer
       testQueue.submit([&](handler &cgh) {
-        auto ptrTemp = bufferTemp.template get_access<access::mode::read>(cgh);
-        auto ptrOut = bufferC.template get_access<access::mode::write>(cgh);
+        auto ptrTemp = bufferTemp.get_access<access::mode::read>(cgh);
+        auto ptrOut = bufferC.get_access<access::mode::write>(cgh);
         cgh.parallel_for<temp_write>(
             range<1>(size), [=](item<1> id) { ptrOut[id] += ptrTemp[id] + 1; });
       });
@@ -77,7 +77,7 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceC != dataC;
+  failed |= referenceC != dataC;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_temp_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer.cpp
@@ -1,0 +1,83 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** This test creates a temporary buffer which is used in kernels but
+ * destroyed before finalization and execution of the graph.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+class vector_add_temp;
+class temp_write;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceC(dataC);
+  for (unsigned n = 0; n < iterations; n++) {
+    for (size_t i = 0; i < size; i++) {
+      referenceC[i] += (dataA[i] + dataB[i]) + 1;
+    }
+  }
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    testQueue.begin_recording(graph);
+
+    // Create a temporary output buffer to use between kernels.
+    {
+      buffer<T> bufferTemp{range<1>{dataA.size()}};
+
+      // Vector add to temporary output buffer
+      testQueue.submit([&](handler &cgh) {
+        auto ptrA = bufferA.template get_access<access::mode::read>(cgh);
+        auto ptrB = bufferB.template get_access<access::mode::read>(cgh);
+        auto ptrOut = bufferTemp.template get_access<access::mode::write>(cgh);
+        cgh.parallel_for<vector_add_temp>(range<1>(size), [=](item<1> id) {
+          ptrOut[id] = ptrA[id] + ptrB[id];
+        });
+      });
+
+      // Modify temp buffer and write to output buffer
+      testQueue.submit([&](handler &cgh) {
+        auto ptrTemp = bufferTemp.template get_access<access::mode::read>(cgh);
+        auto ptrOut = bufferC.template get_access<access::mode::write>(cgh);
+        cgh.parallel_for<temp_write>(
+            range<1>(size), [=](item<1> id) { ptrOut[id] += ptrTemp[id] + 1; });
+      });
+      testQueue.end_recording();
+    }
+    auto graphExec = graph.finalize(testQueue.get_context());
+
+    // Execute several iterations of the graph
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  bool failed = false;
+  failed = referenceC != dataC;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
@@ -41,9 +41,9 @@ int main() {
 
     // Create some temporary buffers only for recording
     {
-      auto bufferA2 = bufferA.template reinterpret<T, 1>(bufferA.get_range());
-      auto bufferB2 = bufferB.template reinterpret<T, 1>(bufferB.get_range());
-      auto bufferC2 = bufferC.template reinterpret<T, 1>(bufferC.get_range());
+      auto bufferA2 = bufferA.reinterpret<T, 1>(bufferA.get_range());
+      auto bufferB2 = bufferB.reinterpret<T, 1>(bufferB.get_range());
+      auto bufferC2 = bufferC.reinterpret<T, 1>(bufferC.get_range());
 
       // Record commands to graph
       run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
@@ -61,9 +61,9 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
@@ -1,0 +1,69 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** This test creates a temporary buffer (which is reinterpreted from the main
+ * application buffers) which is used in kernels but destroyed before
+ * finalization and execution of the graph. The original buffers lifetime
+ * extends until after execution of the graph.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  calculate_reference_data(iterations, size, referenceA, referenceB,
+                           referenceC);
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    testQueue.begin_recording(graph);
+
+    // Create some temporary buffers only for recording
+    {
+      auto bufferA2 = bufferA.template reinterpret<T, 1>(bufferA.get_range());
+      auto bufferB2 = bufferB.template reinterpret<T, 1>(bufferB.get_range());
+      auto bufferC2 = bufferC.template reinterpret<T, 1>(bufferC.get_range());
+
+      // Record commands to graph
+      run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
+
+      testQueue.end_recording();
+    }
+    auto graphExec = graph.finalize(testQueue.get_context());
+
+    // Execute several iterations of the graph
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_threaded.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded.cpp
@@ -1,0 +1,55 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -pthread -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+// Test recording commands to a queue in a threaded situation. We don't
+// submit the graph to verify the results as ordering of graph nodes isn't
+// defined.
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+#include <thread>
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  const unsigned iterations = std::thread::hardware_concurrency();
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    testQueue.begin_recording(graph);
+    auto recordGraph = [&]() {
+      // Record commands to graph
+      run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+    };
+    testQueue.end_recording();
+
+    std::vector<std::thread> threads;
+    threads.reserve(iterations);
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads.emplace_back(recordGraph);
+    }
+
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads[i].join();
+    }
+  }
+
+  return 0;
+}

--- a/SYCL/CommandGraph/graph_record_threaded_change_queue_state.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_change_queue_state.cpp
@@ -1,0 +1,37 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -pthread -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+// Test finalizing and submitting a graph in a threaded situation
+
+#include "graph_common.hpp"
+
+#include <thread>
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  const unsigned iterations = std::thread::hardware_concurrency();
+
+  {
+    auto recordGraph = [&]() {
+      ext::oneapi::experimental::command_graph graph;
+      testQueue.begin_recording(graph);
+      testQueue.end_recording();
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(iterations);
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads.emplace_back(recordGraph);
+    }
+
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads[i].join();
+    }
+  }
+
+  return 0;
+}

--- a/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
@@ -1,0 +1,71 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -pthread -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+// Test finalizing and submitting a graph in a threaded situation
+
+#include "graph_common.hpp"
+
+#include <thread>
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  const unsigned iterations = std::thread::hardware_concurrency();
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  calculate_reference_data(iterations, size, referenceA, referenceB,
+                           referenceC);
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    testQueue.begin_recording(graph);
+
+    // Record commands to graph
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+
+    testQueue.end_recording();
+    auto finalizeGraph = [&]() {
+      auto graphExec = graph.finalize(testQueue.get_context());
+      testQueue.submit(graphExec);
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(iterations);
+
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads.emplace_back(finalizeGraph);
+    }
+
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads[i].join();
+    }
+
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
@@ -63,9 +63,9 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_threaded_record.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_record.cpp
@@ -1,0 +1,54 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -pthread -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+// Test each thread recording the same graph to a different queue.
+
+#include "graph_common.hpp"
+
+#include <thread>
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  const size_t size = 1024;
+  const unsigned iterations = std::thread::hardware_concurrency();
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  {
+    ext::oneapi::experimental::command_graph graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    auto recordGraph = [&]() {
+      queue myQueue;
+
+      // Record commands to graph
+      myQueue.begin_recording(graph);
+      run_kernels(myQueue, size, bufferA, bufferB, bufferC);
+      myQueue.end_recording();
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(iterations);
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads.emplace_back(recordGraph);
+    }
+
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads[i].join();
+    }
+  }
+
+  return 0;
+}

--- a/SYCL/CommandGraph/graph_record_threaded_submit.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_submit.cpp
@@ -62,9 +62,9 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_threaded_submit.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_submit.cpp
@@ -1,0 +1,70 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -pthread -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+// Test calling queue::submit(graph) in a threaded situation
+
+#include "graph_common.hpp"
+
+#include <thread>
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  const unsigned iterations = std::thread::hardware_concurrency();
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  calculate_reference_data(iterations, size, referenceA, referenceB,
+                           referenceC);
+
+  {
+    ext::oneapi::experimental::command_graph<
+        ext::oneapi::experimental::graph_state::modifiable>
+        graph;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    testQueue.begin_recording(graph);
+
+    // Record commands to graph
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+
+    testQueue.end_recording();
+
+    auto graphExec = graph.finalize(testQueue.get_context());
+    auto submitGraph = [&]() { testQueue.submit(graphExec); };
+
+    std::vector<std::thread> threads;
+    threads.reserve(iterations);
+
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads.emplace_back(submitGraph);
+    }
+
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads[i].join();
+    }
+
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_threaded_update.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_update.cpp
@@ -1,0 +1,74 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -pthread -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// XFAIL: *
+
+// Test updating a graph in a threaded situation
+
+#include "graph_common.hpp"
+
+#include <thread>
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  const unsigned iterations = std::thread::hardware_concurrency();
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  auto dataA2 = dataA;
+  auto dataB2 = dataB;
+  auto dataC2 = dataC;
+
+  {
+    ext::oneapi::experimental::command_graph graphA;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    testQueue.begin_recording(graphA);
+
+    // Record commands to graph
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+
+    testQueue.end_recording();
+
+    auto graphExec = graphA.finalize(testQueue.get_context());
+
+    ext::oneapi::experimental::command_graph graphB;
+
+    buffer<T> bufferA2{dataA2.data(), range<1>{dataA2.size()}};
+    buffer<T> bufferB2{dataB2.data(), range<1>{dataB2.size()}};
+    buffer<T> bufferC2{dataC2.data(), range<1>{dataC2.size()}};
+
+    testQueue.begin_recording(graphB);
+
+    // Record commands to graph
+    run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
+
+    testQueue.end_recording();
+
+    auto updateGraph = [&]() { graphExec.update(graphB); };
+
+    std::vector<std::thread> threads;
+    threads.reserve(iterations);
+
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads.emplace_back(updateGraph);
+    }
+
+    for (unsigned i = 0; i < iterations; ++i) {
+      threads[i].join();
+    }
+  }
+
+  return 0;
+}

--- a/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
+++ b/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
@@ -1,0 +1,104 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** Tests recording and submission of a graph containing usm memcpy commands.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+class kernel_mod_a;
+class kernel_mod_b;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  const T modValue = 7;
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  for (size_t i = 0; i < iterations; i++) {
+    for (size_t j = 0; j < size; j++) {
+      referenceA[j] = referenceB[j];
+      referenceA[j] += modValue;
+      referenceB[j] = referenceA[j];
+      referenceB[j] += modValue;
+      referenceC[j] = referenceB[j];
+    }
+  }
+
+  ext::oneapi::experimental::command_graph<
+      ext::oneapi::experimental::graph_state::modifiable>
+      graph;
+
+  {
+    auto ptrA = malloc_device<T>(dataA.size(), testQueue);
+    testQueue.memcpy(ptrA, dataA.data(), dataA.size() * sizeof(T)).wait();
+    auto ptrB = malloc_device<T>(dataB.size(), testQueue);
+    testQueue.memcpy(ptrB, dataB.data(), dataB.size() * sizeof(T)).wait();
+    auto ptrC = malloc_device<T>(dataC.size(), testQueue);
+    testQueue.memcpy(ptrC, dataC.data(), dataC.size() * sizeof(T)).wait();
+
+    testQueue.begin_recording(graph);
+
+    // Record commands to graph
+    // memcpy from B to A
+    testQueue.copy(ptrB, ptrA, size);
+    // Read & write A
+    testQueue.submit([&](handler &cgh) {
+      cgh.parallel_for<kernel_mod_a>(range<1>(size), [=](item<1> id) {
+        auto linID = id.get_linear_id();
+        ptrA[linID] += modValue;
+      });
+    });
+
+    // memcpy from A to B
+    testQueue.copy(ptrA, ptrB, size);
+
+    // Read and write B
+    testQueue.submit([&](handler &cgh) {
+      cgh.parallel_for<kernel_mod_b>(range<1>(size), [=](item<1> id) {
+        auto linID = id.get_linear_id();
+        ptrB[linID] += modValue;
+      });
+    });
+
+    // memcpy from B to C
+    testQueue.copy(ptrB, ptrC, size);
+
+    testQueue.end_recording();
+    auto graphExec = graph.finalize(testQueue.get_context());
+
+    // Execute graph over n iterations
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+
+    testQueue.memcpy(dataA.data(), ptrA, dataA.size() * sizeof(T)).wait();
+    testQueue.memcpy(dataB.data(), ptrB, dataB.size() * sizeof(T)).wait();
+    testQueue.memcpy(dataC.data(), ptrC, dataC.size() * sizeof(T)).wait();
+
+    free(ptrA, testQueue.get_context());
+    free(ptrB, testQueue.get_context());
+    free(ptrC, testQueue.get_context());
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
+++ b/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
@@ -96,9 +96,9 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_valid_no_end.cpp
+++ b/SYCL/CommandGraph/graph_record_valid_no_end.cpp
@@ -1,0 +1,31 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/** Tests obtaining a finalized, executable graph from a graph which is
+ * currently being recorded to (no end_recording called)
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  ext::oneapi::experimental::command_graph graph;
+  {
+    queue myQueue;
+    myQueue.begin_recording(graph);
+  }
+
+  try {
+    auto graphExec = graph.finalize(testQueue.get_context());
+    testQueue.submit(graphExec);
+  } catch (sycl::exception &e) {
+    std::cout << "Exception thrown on finalize or submission.\n";
+    std::abort();
+  }
+  testQueue.wait();
+  return 0;
+}

--- a/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
@@ -78,13 +78,13 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
 
-  failed = referenceA != dataA2;
-  failed = referenceB != dataB2;
-  failed = referenceC != dataC2;
+  failed |= referenceA != dataA2;
+  failed |= referenceB != dataB2;
+  failed |= referenceC != dataC2;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
@@ -1,0 +1,90 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// XFAIL: *
+
+/** Tests whole graph update by recording two graphs with different buffers and
+ * attempting to update one from the other.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  auto dataA2 = dataA;
+  auto dataB2 = dataB;
+  auto dataC2 = dataC;
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  calculate_reference_data(iterations, size, referenceA, referenceB,
+                           referenceC);
+
+  {
+    ext::oneapi::experimental::command_graph graphA;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    testQueue.begin_recording(graphA);
+
+    // Record commands to graph
+
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+
+    testQueue.end_recording();
+
+    auto graphExec = graphA.finalize(testQueue.get_context());
+
+    ext::oneapi::experimental::command_graph graphB;
+
+    buffer<T> bufferA2{dataA2.data(), range<1>{dataA2.size()}};
+    buffer<T> bufferB2{dataB2.data(), range<1>{dataB2.size()}};
+    buffer<T> bufferC2{dataC2.data(), range<1>{dataC2.size()}};
+
+    testQueue.begin_recording(graphB);
+
+    // Record commands to graph
+
+    run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
+
+    testQueue.end_recording();
+    // Execute several iterations of the graph for 1st set of buffers
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+
+    graphExec.update(graphB);
+
+    // Execute several iterations of the graph for 2nd set of buffers
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+
+  failed = referenceA != dataA2;
+  failed = referenceB != dataB2;
+  failed = referenceC != dataC2;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
@@ -52,11 +52,11 @@ int main() {
     testQueue.submit([&](handler &cgh) {
       // This should be access::target::host_task but it has not been
       // implemented yet.
-      auto ptrIn =
-          bufferC.template get_access<access::mode::read_write,
+      auto ptrIn = bufferC.get_access<access::mode::read_write,
                                       access::target::host_buffer>(cgh);
-      auto ptrOut = hostTaskOutputBuffer.template get_access<
-          access::mode::read_write, access::target::host_buffer>(cgh);
+      auto ptrOut =
+          hostTaskOutputBuffer.get_access<access::mode::read_write,
+                                          access::target::host_buffer>(cgh);
       cgh.host_task([=]() {
         for (size_t i = 0; i < size; i++) {
           ptrOut[i] = ptrIn[i];
@@ -85,11 +85,11 @@ int main() {
     testQueue.submit([&](handler &cgh) {
       // This should be access::target::host_task but it has not been
       // implemented yet.
-      auto ptrIn =
-          bufferC2.template get_access<access::mode::read_write,
+      auto ptrIn = bufferC2.get_access<access::mode::read_write,
                                        access::target::host_buffer>(cgh);
-      auto ptrOut = hostTaskOutputBuffer.template get_access<
-          access::mode::read_write, access::target::host_buffer>(cgh);
+      auto ptrOut =
+          hostTaskOutputBuffer.get_access<access::mode::read_write,
+                                          access::target::host_buffer>(cgh);
       cgh.host_task([=]() {
         for (size_t i = 0; i < size; i++) {
           ptrOut[i] = ptrIn[i];
@@ -115,14 +115,14 @@ int main() {
   }
 
   bool failed = false;
-  failed = referenceA != dataA;
-  failed = referenceB != dataB;
-  failed = referenceC != dataC;
-  failed = referenceC != hostTaskOutput;
+  failed |= referenceA != dataA;
+  failed |= referenceB != dataB;
+  failed |= referenceC != dataC;
+  failed |= referenceC != hostTaskOutput;
 
-  failed = referenceA != dataA2;
-  failed = referenceB != dataB2;
-  failed = referenceC != dataC2;
+  failed |= referenceA != dataA2;
+  failed |= referenceB != dataB2;
+  failed |= referenceC != dataC2;
 
   return failed;
 }

--- a/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
@@ -1,0 +1,128 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// XFAIL: *
+
+/** Tests whole graph update by introducing a delay in to the update
+ * transactions dependencies to check correctness of behaviour.
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+class host_task_test;
+
+int main() {
+  queue testQueue;
+
+  using T = int;
+
+  std::vector<T> dataA(size), dataB(size), dataC(size);
+  std::vector<T> hostTaskOutput(size);
+
+  // Initialize the data
+  std::iota(dataA.begin(), dataA.end(), 1);
+  std::iota(dataB.begin(), dataB.end(), 10);
+  std::iota(dataC.begin(), dataC.end(), 1000);
+
+  auto dataA2 = dataA;
+  auto dataB2 = dataB;
+  auto dataC2 = dataC;
+
+  // Create reference data for output
+  std::vector<T> referenceA(dataA), referenceB(dataB), referenceC(dataC);
+  calculate_reference_data(iterations, size, referenceA, referenceB,
+                           referenceC);
+
+  {
+    ext::oneapi::experimental::command_graph graphA;
+    buffer<T> bufferA{dataA.data(), range<1>{dataA.size()}};
+    buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
+    buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
+
+    buffer<T> hostTaskOutputBuffer{hostTaskOutput};
+
+    testQueue.begin_recording(graphA);
+
+    // Record commands to graph
+    run_kernels(testQueue, size, bufferA, bufferB, bufferC);
+
+    // host task to induce a wait for dependencies
+    testQueue.submit([&](handler &cgh) {
+      // This should be access::target::host_task but it has not been
+      // implemented yet.
+      auto ptrIn =
+          bufferC.template get_access<access::mode::read_write,
+                                      access::target::host_buffer>(cgh);
+      auto ptrOut = hostTaskOutputBuffer.template get_access<
+          access::mode::read_write, access::target::host_buffer>(cgh);
+      cgh.host_task([=]() {
+        for (size_t i = 0; i < size; i++) {
+          ptrOut[i] = ptrIn[i];
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+      });
+    });
+
+    testQueue.end_recording();
+
+    auto graphExec = graphA.finalize(testQueue.get_context());
+
+    ext::oneapi::experimental::command_graph graphB;
+
+    buffer<T> bufferA2{dataA2.data(), range<1>{dataA2.size()}};
+    buffer<T> bufferB2{dataB2.data(), range<1>{dataB2.size()}};
+    buffer<T> bufferC2{dataC2.data(), range<1>{dataC2.size()}};
+
+    testQueue.begin_recording(graphB);
+
+    // Record commands to graph
+    run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
+
+    // host task to match the graph topology, but we don't need to sleep this
+    // time because there is no following update.
+    testQueue.submit([&](handler &cgh) {
+      // This should be access::target::host_task but it has not been
+      // implemented yet.
+      auto ptrIn =
+          bufferC2.template get_access<access::mode::read_write,
+                                       access::target::host_buffer>(cgh);
+      auto ptrOut = hostTaskOutputBuffer.template get_access<
+          access::mode::read_write, access::target::host_buffer>(cgh);
+      cgh.host_task([=]() {
+        for (size_t i = 0; i < size; i++) {
+          ptrOut[i] = ptrIn[i];
+        }
+      });
+    });
+
+    testQueue.end_recording();
+    // Execute several iterations of the graph for 1st set of buffers
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+
+    graphExec.update(graphB);
+
+    // Execute several iterations of the graph for 2nd set of buffers
+    for (unsigned n = 0; n < iterations; n++) {
+      testQueue.submit(graphExec);
+    }
+
+    // Perform a wait on all graph submissions.
+    testQueue.wait();
+  }
+
+  bool failed = false;
+  failed = referenceA != dataA;
+  failed = referenceB != dataB;
+  failed = referenceC != dataC;
+  failed = referenceC != hostTaskOutput;
+
+  failed = referenceA != dataA2;
+  failed = referenceB != dataB2;
+  failed = referenceC != dataC2;
+
+  return failed;
+}

--- a/SYCL/CommandGraph/graph_vendor_test_macro.cpp
+++ b/SYCL/CommandGraph/graph_vendor_test_macro.cpp
@@ -1,0 +1,19 @@
+// REQUIRES: level_zero, gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+/**  Tests the existence of the vendor test macro for graphs
+ */
+
+#include "graph_common.hpp"
+
+using namespace sycl;
+
+int main() {
+#ifndef SYCL_EXT_ONEAPI_GRAPH
+  std::cout << "SYCL_EXT_ONEAPI_GRAPH vendor test macro not defined\n";
+  std::abort();
+#else
+  return SYCL_EXT_ONEAPI_GRAPH == 0;
+#endif
+}


### PR DESCRIPTION
Adds tests covering the record and replay side of the command graph extension. Most tests currently fail due to the prototype implementation being incomplete. Tests which rely on graph update are XFAIL for now.