### PR TITLE
[SYCL] exec_graph rename to ext_oneapi_graph

### DIFF
--- a/SYCL/CommandGraph/graph_finalize_empty.cpp
+++ b/SYCL/CommandGraph/graph_finalize_empty.cpp
@@ -18,7 +18,7 @@ int main() {
       graph;
   auto graphExec = graph.finalize(testQueue.get_context());
 
-  testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+  testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
   testQueue.wait();
 
   return 0;

--- a/SYCL/CommandGraph/graph_finalize_empty.cpp
+++ b/SYCL/CommandGraph/graph_finalize_empty.cpp
@@ -18,7 +18,7 @@ int main() {
       graph;
   auto graphExec = graph.finalize(testQueue.get_context());
 
-  testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+  testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
   testQueue.wait();
 
   return 0;

--- a/SYCL/CommandGraph/graph_finalize_empty.cpp
+++ b/SYCL/CommandGraph/graph_finalize_empty.cpp
@@ -18,7 +18,7 @@ int main() {
       graph;
   auto graphExec = graph.finalize(testQueue.get_context());
 
-  testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+  testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
   testQueue.wait();
 
   return 0;

--- a/SYCL/CommandGraph/graph_record_after_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_after_finalize.cpp
@@ -73,11 +73,11 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
     // Execute the extended graph.
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExecAdditional); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExecAdditional); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait_and_throw();

--- a/SYCL/CommandGraph/graph_record_after_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_after_finalize.cpp
@@ -73,11 +73,11 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     }
     // Execute the extended graph.
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExecAdditional); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExecAdditional); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait_and_throw();

--- a/SYCL/CommandGraph/graph_record_after_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_after_finalize.cpp
@@ -73,7 +73,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
     // Execute the extended graph.
     for (unsigned n = 0; n < iterations; n++) {

--- a/SYCL/CommandGraph/graph_record_after_use.cpp
+++ b/SYCL/CommandGraph/graph_record_after_use.cpp
@@ -50,7 +50,7 @@ int main() {
     // Execute several iterations of the graph (first iteration has already run
     // before graph recording)
     for (unsigned n = 1; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_after_use.cpp
+++ b/SYCL/CommandGraph/graph_record_after_use.cpp
@@ -50,7 +50,7 @@ int main() {
     // Execute several iterations of the graph (first iteration has already run
     // before graph recording)
     for (unsigned n = 1; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_after_use.cpp
+++ b/SYCL/CommandGraph/graph_record_after_use.cpp
@@ -50,7 +50,7 @@ int main() {
     // Execute several iterations of the graph (first iteration has already run
     // before graph recording)
     for (unsigned n = 1; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_basic.cpp
+++ b/SYCL/CommandGraph/graph_record_basic.cpp
@@ -46,7 +46,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_basic.cpp
+++ b/SYCL/CommandGraph/graph_record_basic.cpp
@@ -46,7 +46,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_basic.cpp
+++ b/SYCL/CommandGraph/graph_record_basic.cpp
@@ -46,7 +46,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_basic_usm.cpp
+++ b/SYCL/CommandGraph/graph_record_basic_usm.cpp
@@ -49,7 +49,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_basic_usm.cpp
+++ b/SYCL/CommandGraph/graph_record_basic_usm.cpp
@@ -49,7 +49,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_double_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_double_buffer.cpp
@@ -60,10 +60,10 @@ int main() {
     testQueue.end_recording();
 
     for (size_t i = 0; i < iterations; i++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
       // Update to second set of buffers
       execGraph.update(graphUpdate);
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
       // Reset back to original buffers
       execGraph.update(graph);
     }

--- a/SYCL/CommandGraph/graph_record_double_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_double_buffer.cpp
@@ -60,7 +60,7 @@ int main() {
     testQueue.end_recording();
 
     for (size_t i = 0; i < iterations; i++) {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
       // Update to second set of buffers
       execGraph.update(graphUpdate);
       testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });

--- a/SYCL/CommandGraph/graph_record_double_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_double_buffer.cpp
@@ -60,10 +60,10 @@ int main() {
     testQueue.end_recording();
 
     for (size_t i = 0; i < iterations; i++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
       // Update to second set of buffers
       execGraph.update(graphUpdate);
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
       // Reset back to original buffers
       execGraph.update(graph);
     }

--- a/SYCL/CommandGraph/graph_record_host_task.cpp
+++ b/SYCL/CommandGraph/graph_record_host_task.cpp
@@ -78,7 +78,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_host_task.cpp
+++ b/SYCL/CommandGraph/graph_record_host_task.cpp
@@ -78,7 +78,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_host_task.cpp
+++ b/SYCL/CommandGraph/graph_record_host_task.cpp
@@ -78,7 +78,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
+++ b/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
@@ -50,7 +50,7 @@ int main() {
     // before graph recording)
     for (unsigned n = 1; n < iterations; n++) {
       auto graphExec = graph.finalize(testQueue.get_context());
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
+++ b/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
@@ -50,7 +50,7 @@ int main() {
     // before graph recording)
     for (unsigned n = 1; n < iterations; n++) {
       auto graphExec = graph.finalize(testQueue.get_context());
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
+++ b/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
@@ -50,7 +50,7 @@ int main() {
     // before graph recording)
     for (unsigned n = 1; n < iterations; n++) {
       auto graphExec = graph.finalize(testQueue.get_context());
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_queue_shortcuts.cpp
+++ b/SYCL/CommandGraph/graph_record_queue_shortcuts.cpp
@@ -43,16 +43,16 @@ int main() {
     auto graphExec = graph.finalize(testQueue.get_context());
 
     // Execute several iterations of the graph using the different shortcuts
-    event e = testQueue.exec_graph(graphExec);
+    event e = testQueue.ext_oneapi_graph(graphExec);
 
     assert(iterations > 2);
     const unsigned loop_iterations = iterations - 2;
     std::vector<event> events(loop_iterations);
     for (unsigned n = 0; n < loop_iterations; n++) {
-      events[n] = testQueue.exec_graph(graphExec, e);
+      events[n] = testQueue.ext_oneapi_graph(graphExec, e);
     }
 
-    testQueue.exec_graph(graphExec, events).wait();
+    testQueue.ext_oneapi_graph(graphExec, events).wait();
   }
 
   bool failed = false;

--- a/SYCL/CommandGraph/graph_record_stream.cpp
+++ b/SYCL/CommandGraph/graph_record_stream.cpp
@@ -44,7 +44,7 @@ int main() {
 
     auto graphExec = graph.finalize(testQueue.get_context());
 
-    testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+    testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
 
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_stream.cpp
+++ b/SYCL/CommandGraph/graph_record_stream.cpp
@@ -44,7 +44,7 @@ int main() {
 
     auto graphExec = graph.finalize(testQueue.get_context());
 
-    testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+    testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
 
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_stream.cpp
+++ b/SYCL/CommandGraph/graph_record_stream.cpp
@@ -44,7 +44,7 @@ int main() {
 
     auto graphExec = graph.finalize(testQueue.get_context());
 
-    testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+    testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
 
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_sub_graph.cpp
+++ b/SYCL/CommandGraph/graph_record_sub_graph.cpp
@@ -92,7 +92,7 @@ int main() {
       });
     });
 
-    testQueue.submit([&](handler &cgh) { cgh.graph(subGraphExec); });
+    testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(subGraphExec); });
 
     // Copy to another output buffer.
     testQueue.submit([&](handler &cgh) {
@@ -110,7 +110,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(mainGraphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(mainGraphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait_and_throw();

--- a/SYCL/CommandGraph/graph_record_sub_graph.cpp
+++ b/SYCL/CommandGraph/graph_record_sub_graph.cpp
@@ -92,7 +92,7 @@ int main() {
       });
     });
 
-    testQueue.submit([&](handler &cgh) { graphraph(subGraphExec); });
+    testQueue.submit([&](handler &cgh) { cgh.graph(subGraphExec); });
 
     // Copy to another output buffer.
     testQueue.submit([&](handler &cgh) {

--- a/SYCL/CommandGraph/graph_record_sub_graph.cpp
+++ b/SYCL/CommandGraph/graph_record_sub_graph.cpp
@@ -92,7 +92,7 @@ int main() {
       });
     });
 
-    testQueue.submit([&](handler &cgh) { cgh.exec_graph(subGraphExec); });
+    testQueue.submit([&](handler &cgh) { graphraph(subGraphExec); });
 
     // Copy to another output buffer.
     testQueue.submit([&](handler &cgh) {
@@ -110,7 +110,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(mainGraphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(mainGraphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait_and_throw();

--- a/SYCL/CommandGraph/graph_record_temp_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer.cpp
@@ -70,7 +70,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_temp_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer.cpp
@@ -70,7 +70,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_temp_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer.cpp
@@ -70,7 +70,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
@@ -54,7 +54,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
@@ -54,7 +54,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
@@ -54,7 +54,7 @@ int main() {
 
     // Execute several iterations of the graph
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
@@ -44,7 +44,7 @@ int main() {
     testQueue.end_recording();
     auto finalizeGraph = [&]() {
       auto graphExec = graph.finalize(testQueue.get_context());
-      testQueue.submit([&](sycl::handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](sycl::handler &cgh) { cgh.graph(graphExec); });
     };
 
     std::vector<std::thread> threads;

--- a/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
@@ -44,7 +44,7 @@ int main() {
     testQueue.end_recording();
     auto finalizeGraph = [&]() {
       auto graphExec = graph.finalize(testQueue.get_context());
-      testQueue.submit([&](sycl::handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](sycl::handler &cgh) { graphraph(graphExec); });
     };
 
     std::vector<std::thread> threads;

--- a/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
@@ -44,7 +44,7 @@ int main() {
     testQueue.end_recording();
     auto finalizeGraph = [&]() {
       auto graphExec = graph.finalize(testQueue.get_context());
-      testQueue.submit([&](sycl::handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](sycl::handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     };
 
     std::vector<std::thread> threads;

--- a/SYCL/CommandGraph/graph_record_threaded_submit.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_submit.cpp
@@ -45,7 +45,7 @@ int main() {
 
     auto graphExec = graph.finalize(testQueue.get_context());
     auto submitGraph = [&]() {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     };
 
     std::vector<std::thread> threads;

--- a/SYCL/CommandGraph/graph_record_threaded_submit.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_submit.cpp
@@ -45,7 +45,7 @@ int main() {
 
     auto graphExec = graph.finalize(testQueue.get_context());
     auto submitGraph = [&]() {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     };
 
     std::vector<std::thread> threads;

--- a/SYCL/CommandGraph/graph_record_threaded_submit.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_submit.cpp
@@ -45,7 +45,7 @@ int main() {
 
     auto graphExec = graph.finalize(testQueue.get_context());
     auto submitGraph = [&]() {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     };
 
     std::vector<std::thread> threads;

--- a/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
+++ b/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
@@ -81,7 +81,7 @@ int main() {
 
     // Execute graph over n iterations
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
+++ b/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
@@ -81,7 +81,7 @@ int main() {
 
     // Execute graph over n iterations
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
+++ b/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
@@ -81,7 +81,7 @@ int main() {
 
     // Execute graph over n iterations
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait();

--- a/SYCL/CommandGraph/graph_record_valid_no_end.cpp
+++ b/SYCL/CommandGraph/graph_record_valid_no_end.cpp
@@ -21,7 +21,7 @@ int main() {
 
   try {
     auto graphExec = graph.finalize(testQueue.get_context());
-    testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+    testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
   } catch (sycl::exception &e) {
     std::cout << "Exception thrown on finalize or submission.\n";
     std::abort();

--- a/SYCL/CommandGraph/graph_record_valid_no_end.cpp
+++ b/SYCL/CommandGraph/graph_record_valid_no_end.cpp
@@ -21,7 +21,7 @@ int main() {
 
   try {
     auto graphExec = graph.finalize(testQueue.get_context());
-    testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+    testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
   } catch (sycl::exception &e) {
     std::cout << "Exception thrown on finalize or submission.\n";
     std::abort();

--- a/SYCL/CommandGraph/graph_record_valid_no_end.cpp
+++ b/SYCL/CommandGraph/graph_record_valid_no_end.cpp
@@ -21,7 +21,7 @@ int main() {
 
   try {
     auto graphExec = graph.finalize(testQueue.get_context());
-    testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+    testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
   } catch (sycl::exception &e) {
     std::cout << "Exception thrown on finalize or submission.\n";
     std::abort();

--- a/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
@@ -63,7 +63,7 @@ int main() {
     testQueue.end_recording();
     // Execute several iterations of the graph for 1st set of buffers
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
 
     graphExec.update(graphB);

--- a/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
@@ -63,14 +63,14 @@ int main() {
     testQueue.end_recording();
     // Execute several iterations of the graph for 1st set of buffers
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
 
     graphExec.update(graphB);
 
     // Execute several iterations of the graph for 2nd set of buffers
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
 
     // Perform a wait on all graph submissions.

--- a/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
@@ -63,14 +63,14 @@ int main() {
     testQueue.end_recording();
     // Execute several iterations of the graph for 1st set of buffers
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     }
 
     graphExec.update(graphB);
 
     // Execute several iterations of the graph for 2nd set of buffers
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
 
     // Perform a wait on all graph submissions.

--- a/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
@@ -100,7 +100,7 @@ int main() {
     testQueue.end_recording();
     // Execute several iterations of the graph for 1st set of buffers
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
 
     graphExec.update(graphB);

--- a/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
@@ -100,14 +100,14 @@ int main() {
     testQueue.end_recording();
     // Execute several iterations of the graph for 1st set of buffers
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
 
     graphExec.update(graphB);
 
     // Execute several iterations of the graph for 2nd set of buffers
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     }
 
     // Perform a wait on all graph submissions.

--- a/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
@@ -100,14 +100,14 @@ int main() {
     testQueue.end_recording();
     // Execute several iterations of the graph for 1st set of buffers
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { graphraph(graphExec); });
     }
 
     graphExec.update(graphB);
 
     // Execute several iterations of the graph for 2nd set of buffers
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.exec_graph(graphExec); });
+      testQueue.submit([&](handler &cgh) { cgh.graph(graphExec); });
     }
 
     // Perform a wait on all graph submissions.


### PR DESCRIPTION
- In line with the updated graphs specification replace usage of exec_graph with graph