### PR TITLE
[SYCL] Update graph recording mechanism in CommandGraph tests

### DIFF
--- a/SYCL/CommandGraph/graph_queue_info.cpp
+++ b/SYCL/CommandGraph/graph_queue_info.cpp
@@ -21,11 +21,11 @@ int main() {
   ext::oneapi::experimental::command_graph<
       ext::oneapi::experimental::graph_state::modifiable>
       graph;
-  testQueue.begin_recording(graph);
+  graph.begin_recording(testQueue);
   state = testQueue.get_info<info::queue::state>();
   failure |= (state == ext::oneapi::experimental::queue_state::recording);
 
-  testQueue.end_recording();
+  graph.end_recording();
   state = testQueue.get_info<info::queue::state>();
   failure |= (state == ext::oneapi::experimental::queue_state::executing);
 

--- a/SYCL/CommandGraph/graph_record_after_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_after_finalize.cpp
@@ -46,7 +46,7 @@ int main() {
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
     buffer<T> bufferOut{dataOut.data(), range<1>{dataOut.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Vector add to some buffer
     testQueue.submit([&](handler &cgh) {
@@ -66,7 +66,7 @@ int main() {
       cgh.parallel_for<write_to_output>(
           range<1>(size), [=](item<1> id) { ptrOut[id] += ptrC[id] + 1; });
     });
-    testQueue.end_recording();
+    graph.end_recording();
 
     // Finalize a graph with the additional kernel for writing out to
     auto graphExecAdditional = graph.finalize(testQueue.get_context());
@@ -77,7 +77,8 @@ int main() {
     }
     // Execute the extended graph.
     for (unsigned n = 0; n < iterations; n++) {
-      testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExecAdditional); });
+      testQueue.submit(
+          [&](handler &cgh) { cgh.ext_oneapi_graph(graphExecAdditional); });
     }
     // Perform a wait on all graph submissions.
     testQueue.wait_and_throw();

--- a/SYCL/CommandGraph/graph_record_after_use.cpp
+++ b/SYCL/CommandGraph/graph_record_after_use.cpp
@@ -39,12 +39,12 @@ int main() {
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
     testQueue.wait_and_throw();
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Record commands to graph
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
 
-    testQueue.end_recording();
+    graph.end_recording();
     auto graphExec = graph.finalize(testQueue.get_context());
 
     // Execute several iterations of the graph (first iteration has already run

--- a/SYCL/CommandGraph/graph_record_basic.cpp
+++ b/SYCL/CommandGraph/graph_record_basic.cpp
@@ -35,13 +35,13 @@ int main() {
     buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Record commands to graph
 
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
 
-    testQueue.end_recording();
+    graph.end_recording();
     auto graphExec = graph.finalize(testQueue.get_context());
 
     // Execute several iterations of the graph

--- a/SYCL/CommandGraph/graph_record_basic_usm.cpp
+++ b/SYCL/CommandGraph/graph_record_basic_usm.cpp
@@ -38,13 +38,13 @@ int main() {
     auto ptrC = malloc_device<T>(dataC.size(), testQueue);
     testQueue.memcpy(ptrC, dataC.data(), dataC.size() * sizeof(T)).wait();
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Record commands to graph
 
     run_kernels_usm(testQueue, size, ptrA, ptrB, ptrC);
 
-    testQueue.end_recording();
+    graph.end_recording();
     auto graphExec = graph.finalize(testQueue.get_context());
 
     // Execute several iterations of the graph

--- a/SYCL/CommandGraph/graph_record_concurrent_graph.cpp
+++ b/SYCL/CommandGraph/graph_record_concurrent_graph.cpp
@@ -16,11 +16,11 @@ int main() {
   bool success = false;
 
   ext::oneapi::experimental::command_graph graph;
-  testQueue.begin_recording(graph);
+  graph.begin_recording(testQueue);
 
   queue testQueue2;
   try {
-    testQueue2.begin_recording(graph);
+    graph.begin_recording(testQueue2);
   } catch (sycl::exception &e) {
     auto stdErrc = e.code().value();
     if (stdErrc == static_cast<int>(errc::invalid)) {
@@ -28,6 +28,6 @@ int main() {
     }
   }
 
-  testQueue.end_recording();
+  graph.end_recording();
   return success;
 }

--- a/SYCL/CommandGraph/graph_record_concurrent_queue.cpp
+++ b/SYCL/CommandGraph/graph_record_concurrent_queue.cpp
@@ -16,11 +16,11 @@ int main() {
   bool success = false;
 
   ext::oneapi::experimental::command_graph graphA;
-  testQueue.begin_recording(graphA);
+  graphA.begin_recording(testQueue);
 
   try {
     ext::oneapi::experimental::command_graph graphB;
-    testQueue.begin_recording(graphB);
+    graphB.begin_recording(testQueue);
   } catch (sycl::exception &e) {
     auto stdErrc = e.code().value();
     if (stdErrc == static_cast<int>(errc::invalid)) {
@@ -28,7 +28,7 @@ int main() {
     }
   }
 
-  testQueue.end_recording();
+  graphA.end_recording();
 
   return success;
 }

--- a/SYCL/CommandGraph/graph_record_double_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_double_buffer.cpp
@@ -47,17 +47,17 @@ int main() {
     buffer<T> bufferB2{dataB2.data(), range<1>{dataB2.size()}};
     buffer<T> bufferC2{dataC2.data(), range<1>{dataC2.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
-    testQueue.end_recording();
+    graph.end_recording();
 
     auto execGraph = graph.finalize(testQueue.get_context());
 
     // Create second graph using other buffer set
     ext::oneapi::experimental::command_graph graphUpdate;
-    testQueue.begin_recording(graphUpdate);
+    graphUpdate.begin_recording(testQueue);
     run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
-    testQueue.end_recording();
+    graphUpdate.end_recording();
 
     for (size_t i = 0; i < iterations; i++) {
       testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });

--- a/SYCL/CommandGraph/graph_record_finalize_while_recording.cpp
+++ b/SYCL/CommandGraph/graph_record_finalize_while_recording.cpp
@@ -14,7 +14,7 @@ int main() {
   queue testQueue;
 
   ext::oneapi::experimental::command_graph graph;
-  testQueue.begin_recording(graph);
+  graph.begin_recording(testQueue);
 
   try {
     graph.finalize(testQueue.get_context());
@@ -24,6 +24,6 @@ int main() {
     std::abort();
   }
 
-  testQueue.end_recording();
+  graph.end_recording();
   return 0;
 }

--- a/SYCL/CommandGraph/graph_record_host_task.cpp
+++ b/SYCL/CommandGraph/graph_record_host_task.cpp
@@ -41,7 +41,7 @@ int main() {
     buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Vector add to output
     testQueue.submit([&](handler &cgh) {
@@ -72,7 +72,7 @@ int main() {
       cgh.parallel_for<host_task_inc>(range<1>(size),
                                       [=](item<1> id) { ptrOut[id] += 1; });
     });
-    testQueue.end_recording();
+    graph.end_recording();
 
     auto graphExec = graph.finalize(testQueue.get_context());
 

--- a/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
+++ b/SYCL/CommandGraph/graph_record_multiple_exec_graphs.cpp
@@ -39,15 +39,15 @@ int main() {
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
     testQueue.wait_and_throw();
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Record commands to graph
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
 
-    testQueue.end_recording();
+    graph.end_recording();
 
-    // Execute several iterations of the graph (first iteration has already run
-    // before graph recording)
+    // Execute several iterations of the graph (first iteration has already
+    // run before graph recording)
     for (unsigned n = 1; n < iterations; n++) {
       auto graphExec = graph.finalize(testQueue.get_context());
       testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });

--- a/SYCL/CommandGraph/graph_record_queue_shortcuts.cpp
+++ b/SYCL/CommandGraph/graph_record_queue_shortcuts.cpp
@@ -33,13 +33,13 @@ int main() {
     buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Record commands to graph
 
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
 
-    testQueue.end_recording();
+    graph.end_recording();
     auto graphExec = graph.finalize(testQueue.get_context());
 
     // Execute several iterations of the graph using the different shortcuts

--- a/SYCL/CommandGraph/graph_record_return_values.cpp
+++ b/SYCL/CommandGraph/graph_record_return_values.cpp
@@ -12,24 +12,24 @@ using namespace sycl;
 
 int main() {
   queue testQueue;
+  ext::oneapi::experimental::command_graph graph;
 
   bool failure = false;
 
-  bool changedState = testQueue.end_recording();
+  bool changedState = graph.end_recording();
   failure |= changedState;
 
-  ext::oneapi::experimental::command_graph graph;
-  changedState = testQueue.begin_recording(graph);
+  changedState = graph.begin_recording(testQueue);
   failure |= !changedState;
 
   // Recording to same graph is not an exception
-  changedState = testQueue.begin_recording(graph);
+  changedState = graph.begin_recording(testQueue);
   failure |= changedState;
 
-  changedState = testQueue.end_recording();
+  changedState = graph.end_recording();
   failure |= !changedState;
 
-  changedState = testQueue.end_recording();
+  changedState = graph.end_recording();
   failure |= changedState;
 
   return failure;

--- a/SYCL/CommandGraph/graph_record_stream.cpp
+++ b/SYCL/CommandGraph/graph_record_stream.cpp
@@ -30,7 +30,7 @@ int main() {
         graph;
     buffer<T> bufferIn{dataIn.data(), range<1>{dataIn.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Vector add to temporary output buffer
     testQueue.submit([&](handler &cgh) {
@@ -40,7 +40,7 @@ int main() {
         out << "Val: " << accIn[id.get_linear_id()] << sycl::endl;
       });
     });
-    testQueue.end_recording();
+    graph.end_recording();
 
     auto graphExec = graph.finalize(testQueue.get_context());
 

--- a/SYCL/CommandGraph/graph_record_temp_buffer.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer.cpp
@@ -41,7 +41,7 @@ int main() {
     buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Create a temporary output buffer to use between kernels.
     {
@@ -64,7 +64,7 @@ int main() {
         cgh.parallel_for<temp_write>(
             range<1>(size), [=](item<1> id) { ptrOut[id] += ptrTemp[id] + 1; });
       });
-      testQueue.end_recording();
+      graph.end_recording();
     }
     auto graphExec = graph.finalize(testQueue.get_context());
 

--- a/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
+++ b/SYCL/CommandGraph/graph_record_temp_buffer_reinterpret.cpp
@@ -37,7 +37,7 @@ int main() {
     buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Create some temporary buffers only for recording
     {
@@ -48,7 +48,7 @@ int main() {
       // Record commands to graph
       run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
 
-      testQueue.end_recording();
+      graph.end_recording();
     }
     auto graphExec = graph.finalize(testQueue.get_context());
 

--- a/SYCL/CommandGraph/graph_record_threaded.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded.cpp
@@ -33,12 +33,12 @@ int main() {
     buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
     auto recordGraph = [&]() {
       // Record commands to graph
       run_kernels(testQueue, size, bufferA, bufferB, bufferC);
     };
-    testQueue.end_recording();
+    graph.end_recording();
 
     std::vector<std::thread> threads;
     threads.reserve(iterations);

--- a/SYCL/CommandGraph/graph_record_threaded_change_queue_state.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_change_queue_state.cpp
@@ -18,8 +18,8 @@ int main() {
   {
     auto recordGraph = [&]() {
       ext::oneapi::experimental::command_graph graph;
-      testQueue.begin_recording(graph);
-      testQueue.end_recording();
+      graph.begin_recording(testQueue);
+      graph.end_recording();
     };
 
     std::vector<std::thread> threads;

--- a/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_finalize.cpp
@@ -36,15 +36,16 @@ int main() {
     buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Record commands to graph
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
 
-    testQueue.end_recording();
+    graph.end_recording();
     auto finalizeGraph = [&]() {
       auto graphExec = graph.finalize(testQueue.get_context());
-      testQueue.submit([&](sycl::handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
+      testQueue.submit(
+          [&](sycl::handler &cgh) { cgh.ext_oneapi_graph(graphExec); });
     };
 
     std::vector<std::thread> threads;

--- a/SYCL/CommandGraph/graph_record_threaded_record.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_record.cpp
@@ -34,9 +34,9 @@ int main() {
       queue myQueue;
 
       // Record commands to graph
-      myQueue.begin_recording(graph);
+      graph.begin_recording(myQueue);
       run_kernels(myQueue, size, bufferA, bufferB, bufferC);
-      myQueue.end_recording();
+      graph.end_recording();
     };
 
     std::vector<std::thread> threads;

--- a/SYCL/CommandGraph/graph_record_threaded_submit.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_submit.cpp
@@ -36,12 +36,12 @@ int main() {
     buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Record commands to graph
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
 
-    testQueue.end_recording();
+    graph.end_recording();
 
     auto graphExec = graph.finalize(testQueue.get_context());
     auto submitGraph = [&]() {

--- a/SYCL/CommandGraph/graph_record_threaded_update.cpp
+++ b/SYCL/CommandGraph/graph_record_threaded_update.cpp
@@ -34,12 +34,12 @@ int main() {
     buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
 
-    testQueue.begin_recording(graphA);
+    graphA.begin_recording(testQueue);
 
     // Record commands to graph
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
 
-    testQueue.end_recording();
+    graphA.end_recording();
 
     auto graphExec = graphA.finalize(testQueue.get_context());
 
@@ -49,12 +49,12 @@ int main() {
     buffer<T> bufferB2{dataB2.data(), range<1>{dataB2.size()}};
     buffer<T> bufferC2{dataC2.data(), range<1>{dataC2.size()}};
 
-    testQueue.begin_recording(graphB);
+    graphB.begin_recording(testQueue);
 
     // Record commands to graph
     run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
 
-    testQueue.end_recording();
+    graphB.end_recording();
 
     auto updateGraph = [&]() { graphExec.update(graphB); };
 

--- a/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
+++ b/SYCL/CommandGraph/graph_record_usm_memcpy.cpp
@@ -49,7 +49,7 @@ int main() {
     auto ptrC = malloc_device<T>(dataC.size(), testQueue);
     testQueue.memcpy(ptrC, dataC.data(), dataC.size() * sizeof(T)).wait();
 
-    testQueue.begin_recording(graph);
+    graph.begin_recording(testQueue);
 
     // Record commands to graph
     // memcpy from B to A
@@ -76,7 +76,7 @@ int main() {
     // memcpy from B to C
     testQueue.copy(ptrB, ptrC, size);
 
-    testQueue.end_recording();
+    graph.end_recording();
     auto graphExec = graph.finalize(testQueue.get_context());
 
     // Execute graph over n iterations

--- a/SYCL/CommandGraph/graph_record_valid_no_end.cpp
+++ b/SYCL/CommandGraph/graph_record_valid_no_end.cpp
@@ -16,7 +16,7 @@ int main() {
   ext::oneapi::experimental::command_graph graph;
   {
     queue myQueue;
-    myQueue.begin_recording(graph);
+    graph.begin_recording(myQueue);
   }
 
   try {

--- a/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update.cpp
@@ -38,13 +38,13 @@ int main() {
     buffer<T> bufferB{dataB.data(), range<1>{dataB.size()}};
     buffer<T> bufferC{dataC.data(), range<1>{dataC.size()}};
 
-    testQueue.begin_recording(graphA);
+    graphA.begin_recording(testQueue);
 
     // Record commands to graph
 
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
 
-    testQueue.end_recording();
+    graphA.end_recording();
 
     auto graphExec = graphA.finalize(testQueue.get_context());
 
@@ -54,13 +54,13 @@ int main() {
     buffer<T> bufferB2{dataB2.data(), range<1>{dataB2.size()}};
     buffer<T> bufferC2{dataC2.data(), range<1>{dataC2.size()}};
 
-    testQueue.begin_recording(graphB);
+    graphB.begin_recording(testQueue);
 
     // Record commands to graph
 
     run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
 
-    testQueue.end_recording();
+    graphB.end_recording();
     // Execute several iterations of the graph for 1st set of buffers
     for (unsigned n = 0; n < iterations; n++) {
       testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });

--- a/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
+++ b/SYCL/CommandGraph/graph_record_whole_graph_update_ordering.cpp
@@ -43,7 +43,7 @@ int main() {
 
     buffer<T> hostTaskOutputBuffer{hostTaskOutput};
 
-    testQueue.begin_recording(graphA);
+    graphA.begin_recording(testQueue);
 
     // Record commands to graph
     run_kernels(testQueue, size, bufferA, bufferB, bufferC);
@@ -65,7 +65,7 @@ int main() {
       });
     });
 
-    testQueue.end_recording();
+    graphA.end_recording();
 
     auto graphExec = graphA.finalize(testQueue.get_context());
 
@@ -75,7 +75,7 @@ int main() {
     buffer<T> bufferB2{dataB2.data(), range<1>{dataB2.size()}};
     buffer<T> bufferC2{dataC2.data(), range<1>{dataC2.size()}};
 
-    testQueue.begin_recording(graphB);
+    graphB.begin_recording(testQueue);
 
     // Record commands to graph
     run_kernels(testQueue, size, bufferA2, bufferB2, bufferC2);
@@ -97,7 +97,7 @@ int main() {
       });
     });
 
-    testQueue.end_recording();
+    graphB.end_recording();
     // Execute several iterations of the graph for 1st set of buffers
     for (unsigned n = 0; n < iterations; n++) {
       testQueue.submit([&](handler &cgh) { cgh.ext_oneapi_graph(graphExec); });


### PR DESCRIPTION
- Updates CommandGraph recording tests to record on graph object instead of queue